### PR TITLE
fix: update docker-compose to use stack.env for environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     environment:
       - NODE_ENV=production
     env_file:
-      - .env.local
+      - stack.env


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.yml` file to update the environment configuration. The change replaces the `.env.local` file with `stack.env`.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L11-R11): Updated the `env_file` entry from `.env.local` to `stack.env`.